### PR TITLE
Fixed broken build with a newer version of Mysql.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -418,6 +418,9 @@ check_mysql() {
        with_mysql_libs=$lib
        mysql_libname=mysql
        mysql_winlib=1
+    elif test -e "$lib/libmysqlclient.${SHLIB_SUFFIX}"; then
+       with_mysql_libs=$lib
+       mysql_libname=mysqlclient
     elif test -e "$lib/libmariadb.${SHLIB_SUFFIX}"; then
        with_mysql_libs=$lib
        mysql_libname=mariadb


### PR DESCRIPTION
Build was broken because in newest versions libmysqlclient_r is missing and only libmysqlclient is available.

Don't delete branch after merging -> need to merge into develop too.
