### PR TITLE
refs qorelanguage/qore#3750 do not set collation by default to avoid …

### DIFF
--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -59,9 +59,8 @@ major_version * 10000 + minor_version * 100 + sub_version
     - \c "numeric-numbers": return numeric types as arbitrary-precision number values
     - \c "timezone": accepts a string argument that can be either a region name (ex: \c "Europe/Prague") or a UTC offset (ex: \c "+01:00") to set the server's time zone rules; this is useful if connecting to a database server in a different time zone.  If this option is not set then the server's time zone is assumed to be the same as the client's time zone; see @ref mysqltimezone.
 
-    @note if the \c "collation" option is not set, the default value is set to \c "latin1_general_cs" to ensure
-    case-sensitive matches consistent with other databases; if this is not desired, then set the \c "collation"
-    option to the desired value instead.
+    @note if the \c "collation" option is set, the collation is set automatically for each connection to the given
+    value
 
     Options can be set in the \c Datasource or \c DatasourcePool constructors as in the following examples:
     @code

--- a/src/mysql.cpp
+++ b/src/mysql.cpp
@@ -273,13 +273,6 @@ static MYSQL* qore_mysql_init(Datasource* ds, ExceptionSink* xsink) {
     }
 #endif
 
-    // set collation
-    if (mysql_set_collation(db, MYSQL_DEFAULT_COLLATION, xsink)) {
-        assert(*xsink);
-        mysql_close(db);
-        return nullptr;
-    }
-
     return db;
 }
 

--- a/src/qore-mysql.h
+++ b/src/qore-mysql.h
@@ -39,8 +39,6 @@
 
 #define MYSQL_OPT_COLLATION "collation"
 
-#define MYSQL_DEFAULT_COLLATION "latin1_general_cs"
-
 class QoreMysqlConnection;
 
 class MyResult {
@@ -228,7 +226,7 @@ public:
     Datasource& ds;
     const AbstractQoreZoneInfo* server_tz;
     int numeric_support;
-    std::string collation = MYSQL_DEFAULT_COLLATION;
+    std::string collation;
 
     DLLLOCAL QoreMysqlConnection(MYSQL* d, Datasource& n_ds)
         : db(d), ds(n_ds),
@@ -245,13 +243,12 @@ public:
         if (wasInTransaction(ds))
             xsink->raiseException("DBI:MYSQL:CONNECTION-ERROR", "connection to MySQL database server lost while in a transaction; transaction has been lost");
 
-        const char* collation_str;
         MYSQL *new_db = qore_mysql_init(ds, xsink);
         if (!new_db) {
             ds->connectionAborted();
             return -1;
         }
-        if (collation != MYSQL_DEFAULT_COLLATION && mysql_set_collation(new_db, collation.c_str(), xsink)) {
+        if (!collation.empty() && mysql_set_collation(new_db, collation.c_str(), xsink)) {
             return -1;
         }
 

--- a/test/mysql.qtest
+++ b/test/mysql.qtest
@@ -118,7 +118,7 @@ class MysqlTest inherits QUnit::Test {
     collationTest() {
         Datasource db(connstr);
         db.open();
-        assertEq("latin1_general_cs", db.getOption("collation"));
+        assertNothing(db.getOption("collation"));
         assertThrows("MYSQL-COLLATION-ERROR", \db.setOption(), ("collation", "xxx"));
     }
 


### PR DESCRIPTION
…breaking backwardscompatibility