### PR TITLE
fixes #5095: multiple bug fixes, documentation improvements, and test coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ stages:
 default:
   tags:
     - k8s
-    - amd64
   services:
     - name: mariadb:lts
       alias: mysql

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.5...3.29)
 
 project(qore-mysql-module VERSION 2.1)
 

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -10,11 +10,11 @@
     - @ref mysqlstoredprocs
     - @ref mysqlreleasenotes
 
-    @section mysqlintro Introducion to the mysql Module
+    @section mysqlintro Introduction to the mysql Module
 
     The mysql module provides a <a href="www.mysql.com">MySQL</a> driver to Qore's DBI system, allowing Qore programs to access MySQL databases through the Datasource, DatasourcePool, and SQLStatement classes.
 
-    This module is released under the <a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GPL 2</a> and is tagged as such in the module's header (meaning it can only be loaded if the Qore library was initialized from a GPL program as well).
+    This module is released under the <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">LGPL 2.1</a> when compiled with MariaDB, or <a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html">GPL 2</a> when compiled with MySQL (and is tagged as such in the module's header).
 
     Example of creating a MySQL Datasource:
     @code
@@ -78,11 +78,11 @@ major_version * 10000 + minor_version * 100 + sub_version
 
     @section mysqltrans Transaction Management
 
-    This driver sets new connections to use transaction isolation level <tt>read committed</tt>> explicitly for every new connection to conform to Qore's default transaction management style.
+    This driver sets new connections to use transaction isolation level <tt>read committed</tt> explicitly for every new connection to conform to Qore's default transaction management style.
 
     The transaction level can be changed manually, however, using the <tt>Datasource::exec()</tt> method.
 
-    Aditionally the <tt>CLIENT_FOUND_ROWS</tt> option is set for each connection, so <tt>Datasource::exec()</tt> will return the number of rows affected by insert/update queries, etc in a manner consistent with other Qore DBI drivers (if this option is not set and a single row is updated with the same values, 0 would be returned instead of 1 which would not confirm to the behavior of other Qore DBI drivers).
+    Additionally the <tt>CLIENT_FOUND_ROWS</tt> option is set for each connection, so <tt>Datasource::exec()</tt> will return the number of rows affected by insert/update queries, etc in a manner consistent with other Qore DBI drivers (if this option is not set and a single row is updated with the same values, 0 would be returned instead of 1 which would not conform to the behavior of other Qore DBI drivers).
 
     @section mysqlbind Binding and Types
 
@@ -109,24 +109,36 @@ date now = db.selectRow("select current_timestamp into :time").time;
     @subsection mysql_to_qore MySQL to Qore Type Mappings
 
     |!MySQL Type|!Qore Type|!Notes
-    |<tt>TINYINT</tt>|<tt>Type::Int</tt>|direct conversion (note that <tt>BOOL</tt> and <tt>BOOLEAN</tt> are synonyms for this type in ~MySQL)
+    |<tt>TINYINT</tt>|<tt>Type::Int</tt>|direct conversion (note that <tt>BOOL</tt> and <tt>BOOLEAN</tt> are synonyms for this type in MySQL)
     |<tt>SMALLINT</tt>|<tt>Type::Int</tt>|direct conversion
     |<tt>MEDIUMINT</tt>|<tt>Type::Int</tt>|direct conversion
     |<tt>INT</tt>|<tt>Type::Int</tt>|direct conversion
     |<tt>BIGINT</tt>|<tt>Type::Int</tt>|direct conversion
     |<tt>YEAR</tt>|<tt>Type::Int</tt>|direct conversion
+    |<tt>BIT</tt>|<tt>Type::Int</tt>|direct conversion
     |<tt>DECIMAL</tt>|<tt>Type::Int</tt>, <tt>Type::String</tt>, or <tt>Type::Number</tt>|depends on @ref mysqloptions "driver options"
+    |<tt>NUMERIC</tt>|<tt>Type::Int</tt>, <tt>Type::String</tt>, or <tt>Type::Number</tt>|depends on @ref mysqloptions "driver options"
     |<tt>FLOAT</tt>|<tt>Type::Float</tt>|direct conversion
     |<tt>DOUBLE</tt>|<tt>Type::Float</tt>|direct conversion
     |<tt>DATETIME</tt>|<tt>Type::Date</tt>|direct conversion
     |<tt>DATE</tt>|<tt>Type::Date</tt>|direct conversion
     |<tt>TIME</tt>|<tt>Type::Date</tt>|direct conversion; the date portion will be set to January 1, 1970 (start of Qore's 64-bit epoch)
     |<tt>TIMESTAMP</tt>|<tt>Type::Date</tt>|direct conversion
+    |<tt>CHAR</tt>|<tt>Type::String</tt>|direct conversion
+    |<tt>VARCHAR</tt>|<tt>Type::String</tt>|direct conversion
+    |<tt>TEXT</tt>|<tt>Type::String</tt>|direct conversion
+    |<tt>TINYTEXT</tt>|<tt>Type::String</tt>|direct conversion
+    |<tt>MEDIUMTEXT</tt>|<tt>Type::String</tt>|direct conversion
+    |<tt>LONGTEXT</tt>|<tt>Type::String</tt>|direct conversion
     |<tt>BLOB</tt>|<tt>Type::Binary</tt>|direct conversion
     |<tt>TINYBLOB</tt>|<tt>Type::Binary</tt>|direct conversion
     |<tt>MEDIUMBLOB</tt>|<tt>Type::Binary</tt>|direct conversion
+    |<tt>LONGBLOB</tt>|<tt>Type::Binary</tt>|direct conversion
     |<tt>BINARY</tt>|<tt>Type::Binary</tt>|direct conversion
     |<tt>VARBINARY</tt>|<tt>Type::Binary</tt>|direct conversion
+    |<tt>ENUM</tt>|<tt>Type::String</tt>|returned as string value
+    |<tt>SET</tt>|<tt>Type::String</tt>|returned as comma-separated string value
+    |<tt>JSON</tt>|<tt>Type::String</tt>|returned as JSON string (MySQL 5.7+)
 
     @subsection mysql_binding_by_value Binding By Value
 
@@ -168,7 +180,13 @@ hash: (1 member)
     @section mysqlreleasenotes Release Notes
 
     @subsection mysql2_1 mysql Driver Version 2.1
+    <b>New Features and Bug Fixes</b>
     - updated build to use the latest %Qore APIs
+    - fixed error message in \c mysql_stmt_api_bind_placeholders() that incorrectly referenced "pgsql" driver
+    - fixed missing error handling in \c MyResult::bind() for \c mysql_stmt_bind_result() failures
+    - fixed debug printf format string mismatch in \c QoreMysqlBindGroup::add()
+    - updated documentation with expanded type mappings and fixed typos
+    - added comprehensive negative test cases for better test coverage
 
     @subsection mysql2021 mysql Driver Version 2.0.2.1
     <b>New Features and Bug Fixes</b>

--- a/src/mysql.cpp
+++ b/src/mysql.cpp
@@ -6,7 +6,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -337,9 +337,9 @@ void MyResult::setupColumns(QoreHashNode& h) {
       assign_column_value(tstr, enc, field[i].name, h, new QoreListNode);
 }
 
-void MyResult::bind(MYSQL_STMT *stmt) {
+int MyResult::bind(MYSQL_STMT *stmt) {
     if (bindbuf)
-        return;
+        return 0;
 
     bindbuf = new MYSQL_BIND[num_fields];
     bi      = new bindInfo[num_fields];
@@ -404,8 +404,11 @@ void MyResult::bind(MYSQL_STMT *stmt) {
         bindbuf[i].length = &bi[i].mlen;
     }
 
-    // FIXME: check for errors here
-    mysql_stmt_bind_result(stmt, bindbuf);
+    if (mysql_stmt_bind_result(stmt, bindbuf)) {
+        // return error code; caller should check mysql_stmt_error() for details
+        return -1;
+    }
+    return 0;
 }
 
 QoreValue MyResult::getBoundColumnValue(int i, bool destructive) {
@@ -784,7 +787,10 @@ QoreHashNode* QoreMysqlBindGroup::getOutputHash(ExceptionSink* xsink) {
 
             int rows = mysql_stmt_affected_rows(tmp_stmt);
             if (rows) {
-                tmpres.bind(tmp_stmt);
+                if (tmpres.bind(tmp_stmt)) {
+                    xsink->raiseException("DBI:MYSQL:BIND-ERROR", "error binding result columns: %s", mysql_stmt_error(tmp_stmt));
+                    return nullptr;
+                }
 
                 if (rows > 1) {
                     QoreListNode* l = new QoreListNode(autoTypeInfo);
@@ -880,7 +886,10 @@ QoreValue QoreMysqlBindGroup::exec(ExceptionSink* xsink, bool cols) {
         if (!mysql_stmt_affected_rows(stmt))
             return h.release();
 
-        myres.bind(stmt);
+        if (myres.bind(stmt)) {
+            xsink->raiseException("DBI:MYSQL:BIND-ERROR", "error binding result columns: %s", mysql_stmt_error(stmt));
+            return QoreValue();
+        }
 
         return getDataColumns(**h, xsink, -1, cols) ? QoreValue() : h.release();
     }
@@ -900,7 +909,10 @@ QoreValue QoreMysqlBindGroup::selectRows(ExceptionSink* xsink) {
         if (!mysql_stmt_affected_rows(stmt))
             return l.release();
 
-        myres.bind(stmt);
+        if (myres.bind(stmt)) {
+            xsink->raiseException("DBI:MYSQL:BIND-ERROR", "error binding result columns: %s", mysql_stmt_error(stmt));
+            return QoreValue();
+        }
 
         return getDataRows(**l, xsink) ? QoreValue() : l.release();
     }
@@ -923,7 +935,10 @@ QoreHashNode* QoreMysqlBindGroup::selectRow(ExceptionSink* xsink) {
             return nullptr;
         }
 
-        myres.bind(stmt);
+        if (myres.bind(stmt)) {
+            xsink->raiseException("DBI:MYSQL:BIND-ERROR", "error binding result columns: %s", mysql_stmt_error(stmt));
+            return nullptr;
+        }
 
         QoreString tstr;
         const QoreEncoding* enc = ds->getQoreEncoding();
@@ -1076,8 +1091,12 @@ int QoreMysqlPreparedStatement::bind(const QoreListNode &l, ExceptionSink *xsink
 
 int QoreMysqlPreparedStatement::define(ExceptionSink *xsink) {
    //printd(5, "QoreMysqlPreparedStatement::define() this: %p myres: %d\n", this, (bool)myres);
-   if (myres)
-      myres.bind(stmt);
+   if (myres) {
+      if (myres.bind(stmt)) {
+         xsink->raiseException("DBI:MYSQL:BIND-ERROR", "error binding result columns: %s", mysql_stmt_error(stmt));
+         return -1;
+      }
+   }
    return 0;
 }
 
@@ -1242,7 +1261,7 @@ static int mysql_stmt_api_bind(SQLStatement* stmt, const QoreListNode& l, Except
 }
 
 static int mysql_stmt_api_bind_placeholders(SQLStatement* stmt, const QoreListNode& l, ExceptionSink* xsink) {
-   xsink->raiseException("DBI:PGSQL-BIND-PLACEHHODERS-ERROR", "binding placeholders is not necessary or supported with the pgsql driver");
+   xsink->raiseException("DBI:MYSQL-BIND-PLACEHOLDERS-ERROR", "binding placeholders is not necessary or supported with the mysql driver");
    return -1;
 }
 

--- a/src/qore-mysql.h
+++ b/src/qore-mysql.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2020 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -107,7 +107,7 @@ public:
       return (bool)num_fields;
    }
 
-   DLLLOCAL void bind(MYSQL_STMT *stmt);
+   DLLLOCAL int bind(MYSQL_STMT *stmt);
    DLLLOCAL QoreValue getBoundColumnValue(int i, bool destructive = false);
 
    DLLLOCAL char *getFieldName(int i) {
@@ -437,7 +437,7 @@ public:
 
     DLLLOCAL void add(char *name) {
         phl.push_back(name);
-        printd(5, "QoreMysqlBindGroup::add() placeholder '%s' %d %s\n", name);
+        printd(5, "QoreMysqlBindGroup::add() placeholder '%s'\n", name);
         hasOutput = true;
     }
 

--- a/test/mysql.qtest
+++ b/test/mysql.qtest
@@ -113,6 +113,17 @@ class MysqlTest inherits QUnit::Test {
         addTestCase("transaction test case", \transactionTests());
         addTestCase("select row test", \selectRowTest());
 
+        # New comprehensive test cases
+        addTestCase("NULL handling test", \nullHandlingTest());
+        addTestCase("boundary values test", \boundaryValuesTest());
+        addTestCase("SQL error test", \sqlErrorTest());
+        addTestCase("prepared statement test", \preparedStatementTest());
+        addTestCase("empty result test", \emptyResultTest());
+        addTestCase("type conversion test", \typeConversionTest());
+        addTestCase("binary data test", \binaryDataTest());
+        addTestCase("number options test", \numberOptionsTest());
+        addTestCase("timezone test", \timezoneTest());
+
         set_return_value(main());
     }
 
@@ -349,5 +360,435 @@ class MysqlTest inherits QUnit::Test {
             db.rollback();
 
         assertThrows("DBI-SELECT-ROW-ERROR", \db.selectRow(), "select * from family");
+    }
+
+    # Test NULL value handling
+    nullHandlingTest() {
+        Datasource db(connstr);
+
+        on_exit {
+            try { db.exec("drop table null_test"); } catch () {}
+            db.commit();
+        }
+
+        # Create table with nullable columns
+        db.exec("create table null_test (
+            id int not null,
+            nullable_int int null,
+            nullable_varchar varchar(100) null,
+            nullable_date date null,
+            nullable_blob blob null
+        )");
+        db.commit();
+
+        # Insert NULL values
+        db.exec("insert into null_test values (1, NULL, NULL, NULL, NULL)");
+        db.exec("insert into null_test values (2, 42, 'test', '2024-01-15', NULL)");
+        db.commit();
+
+        # Test selecting NULL values
+        *hash row = db.selectRow("select * from null_test where id = 1");
+        assertEq(1, row.id);
+        assertEq(NULL, row.nullable_int);
+        assertEq(NULL, row.nullable_varchar);
+        assertEq(NULL, row.nullable_date);
+        assertEq(NULL, row.nullable_blob);
+
+        # Test selecting non-NULL values
+        row = db.selectRow("select * from null_test where id = 2");
+        assertEq(2, row.id);
+        assertEq(42, row.nullable_int);
+        assertEq("test", row.nullable_varchar);
+
+        # Test binding NULL values
+        db.exec("insert into null_test values (3, %v, %v, %v, %v)", NULL, NULL, NULL, NULL);
+        db.commit();
+        row = db.selectRow("select * from null_test where id = 3");
+        assertEq(NULL, row.nullable_int);
+        assertEq(NULL, row.nullable_varchar);
+    }
+
+    # Test boundary values for various data types
+    boundaryValuesTest() {
+        Datasource db(connstr);
+
+        on_exit {
+            try { db.exec("drop table boundary_test"); } catch () {}
+            db.commit();
+        }
+
+        # Create table for boundary testing
+        db.exec("create table boundary_test (
+            id int not null,
+            tiny_val tinyint,
+            small_val smallint,
+            int_val int,
+            big_val bigint,
+            float_val float,
+            double_val double,
+            decimal_val decimal(20,5),
+            varchar_val varchar(255),
+            text_val text
+        )");
+        db.commit();
+
+        # Test BIGINT boundaries
+        int bigint_max = 9223372036854775807;
+        int bigint_min = -9223372036854775807;  # Use -max to avoid overflow
+        db.exec("insert into boundary_test (id, big_val) values (1, %v)", bigint_max);
+        db.exec("insert into boundary_test (id, big_val) values (2, %v)", bigint_min);
+        db.commit();
+
+        *hash row = db.selectRow("select big_val from boundary_test where id = 1");
+        assertEq(bigint_max, row.big_val);
+        row = db.selectRow("select big_val from boundary_test where id = 2");
+        assertEq(bigint_min, row.big_val);
+
+        # Test TINYINT boundaries
+        db.exec("insert into boundary_test (id, tiny_val) values (3, 127)");
+        db.exec("insert into boundary_test (id, tiny_val) values (4, -128)");
+        db.commit();
+
+        row = db.selectRow("select tiny_val from boundary_test where id = 3");
+        assertEq(127, row.tiny_val);
+        row = db.selectRow("select tiny_val from boundary_test where id = 4");
+        assertEq(-128, row.tiny_val);
+
+        # Test empty string
+        db.exec("insert into boundary_test (id, varchar_val) values (5, '')");
+        db.commit();
+        row = db.selectRow("select varchar_val from boundary_test where id = 5");
+        assertEq("", row.varchar_val);
+
+        # Test long text
+        string long_text = strmul("x", 10000);
+        db.exec("insert into boundary_test (id, text_val) values (6, %v)", long_text);
+        db.commit();
+        row = db.selectRow("select text_val from boundary_test where id = 6");
+        assertEq(long_text, row.text_val);
+    }
+
+    # Test SQL error handling
+    sqlErrorTest() {
+        Datasource db(connstr);
+
+        on_exit
+            db.rollback();
+
+        # Test syntax error - can throw various DBI:MYSQL exceptions
+        bool got_error = False;
+        try {
+            db.exec("SELEC * FROM nonexistent");
+        } catch (hash<auto> ex) {
+            got_error = True;
+            assertTrue(ex.err =~ /DBI:MYSQL/);
+        }
+        assertTrue(got_error);
+
+        # Test table not found
+        got_error = False;
+        try {
+            db.exec("select * from table_that_does_not_exist_xyz");
+        } catch (hash<auto> ex) {
+            got_error = True;
+            assertTrue(ex.err =~ /DBI:MYSQL/);
+        }
+        assertTrue(got_error);
+
+        # Test constraint violation - duplicate key
+        got_error = False;
+        try {
+            db.exec("create table dup_test (id int primary key)");
+            db.exec("insert into dup_test values (1)");
+            db.exec("insert into dup_test values (1)");  # duplicate
+        } catch (hash<auto> ex) {
+            got_error = True;
+            assertTrue(ex.err =~ /DBI:MYSQL/);
+        }
+        assertTrue(got_error);
+        db.rollback();
+        try { db.exec("drop table dup_test"); } catch () {}
+        db.commit();
+
+        # Test invalid column reference
+        got_error = False;
+        try {
+            db.select("select nonexistent_column from family");
+        } catch (hash<auto> ex) {
+            got_error = True;
+            assertTrue(ex.err =~ /DBI:MYSQL/);
+        }
+        assertTrue(got_error);
+    }
+
+    # Test prepared statement operations
+    preparedStatementTest() {
+        Datasource db(connstr);
+
+        on_exit {
+            try { db.exec("drop table stmt_test"); } catch () {}
+            db.commit();
+        }
+
+        db.exec("create table stmt_test (id int, name varchar(100), value decimal(10,2))");
+        db.commit();
+
+        # Test SQLStatement basic usage
+        SQLStatement stmt(db);
+        stmt.prepare("insert into stmt_test values (%v, %v, %v)");
+
+        stmt.bind(1, "first", 10.50);
+        stmt.exec();
+        stmt.commit();
+
+        # Re-bind and execute with different values
+        stmt.bind(2, "second", 20.75);
+        stmt.exec();
+        stmt.commit();
+
+        # Verify data
+        *list rows = db.selectRows("select * from stmt_test order by id");
+        assertEq(2, rows.size());
+        assertEq(1, rows[0].id);
+        assertEq("first", rows[0].name);
+        assertEq(2, rows[1].id);
+        assertEq("second", rows[1].name);
+
+        # Test select with prepared statement
+        SQLStatement sel_stmt(db);
+        sel_stmt.prepare("select * from stmt_test where id = %v");
+        sel_stmt.bind(1);
+        sel_stmt.exec();
+        assertTrue(sel_stmt.next());
+        *hash row = sel_stmt.fetchRow();
+        assertEq("first", row.name);
+        sel_stmt.commit();
+
+        # Test affected rows
+        SQLStatement upd_stmt(db);
+        upd_stmt.prepare("update stmt_test set name = %v where id > 0");
+        upd_stmt.bind("updated");
+        upd_stmt.exec();
+        assertEq(2, upd_stmt.affectedRows());
+        upd_stmt.commit();
+    }
+
+    # Test empty result set handling
+    emptyResultTest() {
+        Datasource db(connstr);
+
+        on_exit
+            db.rollback();
+
+        # Test selectRow with no results - should return NOTHING
+        *hash row = db.selectRow("select * from family where family_id = 9999");
+        assertNothing(row);
+
+        # Test selectRows with no results
+        *list rows = db.selectRows("select * from family where family_id = 9999");
+        assertEq((), rows);
+
+        # Test select with no results
+        hash result = db.select("select * from family where family_id = 9999");
+        assertEq(0, result.family_id.size());
+        assertEq(0, result.name.size());
+
+        # Test SQLStatement with empty result
+        SQLStatement stmt(db);
+        stmt.prepare("select * from family where family_id = 9999");
+        stmt.exec();
+        assertFalse(stmt.next());
+        stmt.commit();
+    }
+
+    # Test type conversion for various MySQL types
+    typeConversionTest() {
+        Datasource db(connstr);
+
+        on_exit {
+            try { db.exec("drop table type_test"); } catch () {}
+            db.commit();
+        }
+
+        db.exec("create table type_test (
+            id int not null,
+            bool_val tinyint(1),
+            year_val year,
+            time_val time,
+            enum_val enum('one', 'two', 'three'),
+            set_val set('a', 'b', 'c')
+        )");
+        db.commit();
+
+        # Test boolean binding
+        db.exec("insert into type_test (id, bool_val) values (1, %v)", True);
+        db.exec("insert into type_test (id, bool_val) values (2, %v)", False);
+        db.commit();
+
+        *hash row = db.selectRow("select bool_val from type_test where id = 1");
+        assertEq(1, row.bool_val);
+        row = db.selectRow("select bool_val from type_test where id = 2");
+        assertEq(0, row.bool_val);
+
+        # Test YEAR type
+        db.exec("insert into type_test (id, year_val) values (3, 2024)");
+        db.commit();
+        row = db.selectRow("select year_val from type_test where id = 3");
+        assertEq(2024, row.year_val);
+
+        # Test TIME type
+        db.exec("insert into type_test (id, time_val) values (4, '14:30:45')");
+        db.commit();
+        row = db.selectRow("select time_val from type_test where id = 4");
+        # TIME values should have date set to 1970-01-01
+        assertEq(14, get_hours(row.time_val));
+        assertEq(30, get_minutes(row.time_val));
+        assertEq(45, get_seconds(row.time_val));
+
+        # Test ENUM type
+        db.exec("insert into type_test (id, enum_val) values (5, 'two')");
+        db.commit();
+        row = db.selectRow("select enum_val from type_test where id = 5");
+        assertEq("two", row.enum_val);
+
+        # Test SET type
+        db.exec("insert into type_test (id, set_val) values (6, 'a,c')");
+        db.commit();
+        row = db.selectRow("select set_val from type_test where id = 6");
+        assertEq("a,c", row.set_val);
+    }
+
+    # Test binary data handling
+    binaryDataTest() {
+        Datasource db(connstr);
+
+        on_exit {
+            try { db.exec("drop table binary_test"); } catch () {}
+            db.commit();
+        }
+
+        db.exec("create table binary_test (
+            id int not null,
+            bin_data blob,
+            vbin_data varbinary(255)
+        )");
+        db.commit();
+
+        # Test binary data with various content
+        binary test_bin = <deadbeef>;
+        db.exec("insert into binary_test (id, bin_data, vbin_data) values (1, %v, %v)", test_bin, test_bin);
+        db.commit();
+
+        *hash row = db.selectRow("select * from binary_test where id = 1");
+        assertEq(test_bin, row.vbin_data);
+
+        # Test empty binary
+        binary empty_bin = binary();
+        db.exec("insert into binary_test (id, bin_data) values (2, %v)", empty_bin);
+        db.commit();
+
+        row = db.selectRow("select bin_data from binary_test where id = 2");
+        # Empty binary should be NULL or empty: verify the column exists in result
+        assertTrue(row.hasKey("bin_data"));
+        # If not NULL, should be empty
+        if (exists row.bin_data) {
+            assertEq(0, row.bin_data.size());
+        }
+
+        # Test larger binary data
+        binary large_bin = binary(strmul("X", 1000));
+        db.exec("insert into binary_test (id, bin_data) values (3, %v)", large_bin);
+        db.commit();
+
+        row = db.selectRow("select bin_data from binary_test where id = 3");
+        assertEq(large_bin.size(), row.bin_data.size());
+    }
+
+    # Test number option handling
+    numberOptionsTest() {
+        Datasource db(connstr);
+        db.open();
+
+        on_exit {
+            try { db.exec("drop table number_test"); } catch () {}
+            db.commit();
+        }
+
+        db.exec("create table number_test (
+            id int not null,
+            dec_val decimal(20,5),
+            num_val numeric(15,3)
+        )");
+        db.commit();
+
+        # Insert test data
+        db.exec("insert into number_test values (1, 123456789.12345, 9999999.999)");
+        db.commit();
+
+        # Test optimal-numbers (default)
+        db.setOption("optimal-numbers", True);
+        *hash row = db.selectRow("select * from number_test where id = 1");
+        # With optimal-numbers, non-integer decimals should be returned as number type
+        assertTrue(exists row.dec_val);
+
+        # Test string-numbers - verify the option works without breaking
+        db.setOption("string-numbers", True);
+        row = db.selectRow("select * from number_test where id = 1");
+        assertTrue(exists row.dec_val);
+        assertTrue(exists row.num_val);
+
+        # Test numeric-numbers
+        db.setOption("numeric-numbers", True);
+        row = db.selectRow("select * from number_test where id = 1");
+        assertTrue(exists row.dec_val);
+        assertTrue(exists row.num_val);
+
+        # Reset to optimal
+        db.setOption("optimal-numbers", True);
+    }
+
+    # Test timezone handling
+    timezoneTest() {
+        Datasource db(connstr);
+        db.open();
+
+        on_exit {
+            try { db.exec("drop table tz_test"); } catch () {}
+            db.commit();
+        }
+
+        db.exec("create table tz_test (
+            id int not null,
+            dt datetime,
+            ts timestamp
+        )");
+        db.commit();
+
+        # Test with a specific date/time
+        date test_dt = 2024-06-15T14:30:00;
+        db.exec("insert into tz_test values (1, %v, %v)", test_dt, test_dt);
+        db.commit();
+
+        *hash row = db.selectRow("select * from tz_test where id = 1");
+        assertEq(2024, get_years(row.dt));
+        assertEq(6, get_months(row.dt));
+        assertEq(15, get_days(row.dt));
+        assertEq(14, get_hours(row.dt));
+        assertEq(30, get_minutes(row.dt));
+
+        # Test timezone option (if valid timezone available)
+        try {
+            db.setOption("timezone", "UTC");
+            # Insert and retrieve with UTC timezone
+            db.exec("insert into tz_test values (2, %v, %v)", test_dt, test_dt);
+            db.commit();
+            row = db.selectRow("select * from tz_test where id = 2");
+            # Verify the date was stored correctly
+            assertEq(2024, get_years(row.dt));
+        } catch (hash<auto> ex) {
+            # Timezone setting may not be available in all configurations
+            if (ex.err != "MYSQL-OPTION-ERROR")
+                rethrow;
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses multiple issues identified during a comprehensive code analysis of the mysql module.

Closes qoretechnologies/qore#5095

### Bug Fixes
- Fixed error message in `mysql_stmt_api_bind_placeholders()` that incorrectly referenced "pgsql" driver with misspelled error code ("DBI:PGSQL-BIND-PLACEHHODERS-ERROR" → "DBI:MYSQL-BIND-PLACEHOLDERS-ERROR")
- Added missing error handling in `MyResult::bind()` for `mysql_stmt_bind_result()` failures - the return value was previously ignored
- Fixed debug printf format string mismatch in `QoreMysqlBindGroup::add()` (3 format specifiers but only 1 argument)
- Updated CMake minimum version to 3.5 for compatibility with modern CMake
- Updated copyright year to 2025

### CI Fixes
- Removed `amd64` tag from GitLab CI configuration

### Documentation Improvements
- Fixed typo "Introducion" → "Introduction"
- Fixed typo "read committed>>" → "read committed" (extra `>`)
- Fixed typo "Aditionally" → "Additionally"
- Fixed typo "confirm" → "conform"
- Clarified license statement (LGPL 2.1 for MariaDB, GPL 2 for MySQL)
- Expanded type mapping table with missing types: TEXT variants, LONGBLOB, BIT, NUMERIC, ENUM, SET, JSON, CHAR, VARCHAR
- Added detailed release notes for version 2.1

### Test Coverage Enhancements
Added 9 new comprehensive test cases (437 lines):
- NULL value handling tests
- Boundary value tests (BIGINT min/max, TINYINT, empty strings, large text)
- SQL error handling tests (syntax errors, missing tables, constraint violations)
- Prepared statement operation tests
- Empty result set handling tests
- Type conversion tests (BOOL, YEAR, TIME, ENUM, SET)
- Binary data handling tests
- Number options tests (optimal-numbers, string-numbers, numeric-numbers)
- Timezone handling tests

## Test Plan
- [x] All 14 test cases pass (73 assertions)
- [x] Valgrind shows 0 memory errors and 0 definitely lost bytes
- [x] Module builds successfully with latest Qore APIs
- [x] GitLab CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)